### PR TITLE
fix: handle annotations without args

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -117,7 +117,7 @@ const parseBru = (bruText) => {
     if (isAnnotation) {
       const parts = currentLine.split('(', 2);
       const annotationName = parts[0].slice(1);
-      const annotationArgs = parts[1].slice(0, -1).split(',').map(arg => arg.trim());
+      let annotationArgs = parts[1] && parts[1].length ? parts[1].slice(0, -1).split(',').map(arg => arg.trim()) : []
 
       if (ast.type === 'multimap') {
         ast.annotations = ast.annotations || [];

--- a/tests/parse/annotations.spec.js
+++ b/tests/parse/annotations.spec.js
@@ -1,6 +1,29 @@
 const parse = require('../../src/parse')
 
 describe('bru parse()', () => {
+  it('should parse a annotation with no args', () => {
+    const input = `
+@ignore
+name: Bruno
+`;
+
+    const expected = {
+      type: 'multimap',
+      value: [{
+        type: 'pair',
+        key: 'name',
+        value: 'Bruno',
+        annotations: [{
+          name: 'ignore',
+          args: []
+        }]
+      }]
+    }
+
+    const actual = parse(input);
+    expect(actual).toEqual(expected);
+  })
+
   it('should parse a annotation on a key value pair', () => {
     const input = `
 @description(Name)


### PR DESCRIPTION
Adds a tiny null check to allow annotations to be parsed even without params. 